### PR TITLE
Fixed right click functions in wilderness when (-1,-1,-1) is claimed

### DIFF
--- a/src/main/java/lusii/lusiiclaimchunks/mixins/NetServerHandlerMixin.java
+++ b/src/main/java/lusii/lusiiclaimchunks/mixins/NetServerHandlerMixin.java
@@ -83,6 +83,7 @@ public class NetServerHandlerMixin extends NetHandler implements ICommandListene
 	}
 	@Inject(method = "handlePlace", at = @At("HEAD"), cancellable = true)
 	public void handlePlaceChunkClaim(Packet15Place packet, CallbackInfo ci) {
+		if(packet.yPosition < 0){return;}
         int x = packet.xPosition;
 		int y = packet.yPosition;
 		int z = packet.zPosition;


### PR DESCRIPTION
When right clicking items, BTA points to -1 -1 -1 instead of the player position for some ungodly reason... so if the world origin is claimed, no one other than the owner can do item functions. I fixed it lol